### PR TITLE
Changed wording for SLA SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,7 +21,7 @@ A member of the team will acknowledge receipt of your report promptly and coordi
 
 Upon receiving a security vulnerability report, our team will:
 
-1. **Acknowledge receipt** of your report within 24-48 hours.
+1. **Acknowledge receipt** of your report as soon as possible, typically within 24-48 hours.
 2. Assign a primary handler responsible for verifying and addressing the issue.
 3. Confirm the vulnerability and identify affected versions.
 4. Perform a comprehensive audit to detect similar vulnerabilities.


### PR DESCRIPTION

## Description

Changed the wording from a 24-48 hour commitment to a more realistic ASAP, typically within 24-48 hours.


## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](https://github.com/Verizon/verizon_burp_extensions_ai/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
